### PR TITLE
example horizontal bars updated

### DIFF
--- a/lcars/index.html
+++ b/lcars/index.html
@@ -318,9 +318,9 @@
 							<a>left-top</a>
 						</div>
 						<div class="lcars-bar spacer"></div>
-							<div class="lcars-bar horizontal-grayBlue bottom both-divider"></div>
+						<div class="lcars-bar horizontal lcars-blue-bell-bg bottom both-divider"></div>
 						<div class="lcars-bar spacer"></div>
-						<div class="lcars-bar horizontal-purple right-end bottom"></div>
+						<div class="lcars-bar horizontal lcars-lavender-purple-bg right-end bottom"></div>
 				</div>
 				</p>
 				<p>
@@ -333,9 +333,9 @@
 							<a>left-bottom</a>
 						</div>
 						<div class="lcars-bar spacer"></div>
-						<div class="lcars-bar horizontal-blue right-divider"></div>
+						<div class="lcars-bar horizontal lcars-dodger-blue-bg right-divider"></div>
 						<div class="lcars-bar spacer"></div>
-						<div class="lcars-bar horizontal-tan right-end"></div>
+						<div class="lcars-bar horizontal lcars-tan-bg right-end"></div>
 					</div>
 				</p>
 


### PR DESCRIPTION
The four lines now use valid `-bg` classes for the colors and correct the `horizontal` class name.

This lets the example show the horizontal bars that connect with the elbows.