### PR TITLE
Update gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var ENVIRONMENT = 'development' // 'production'
   coreFiles: './lcars/stylus/*.styl'
 };
 
-gulp.task('compile-dev', function() {
+gulp.task('compile-dev', function(done) {
   gulp.src('./lcars/stylus/lcars_devel.styl')
     .pipe(
       stylus({
@@ -28,9 +28,10 @@ gulp.task('compile-dev', function() {
     )
     .pipe( rename('lcars.devel.css') )
     .pipe( gulp.dest('./lcars/css') );
+  done();
 });
 
-gulp.task('compile', function() {
+gulp.task('compile', function(done) {
   gulp.src('./lcars/stylus/lcars.styl')
     .pipe(
       stylus({
@@ -42,9 +43,10 @@ gulp.task('compile', function() {
       })
     )
     .pipe( gulp.dest('./lcars/css') );
+  done();
 });
 
-gulp.task('compile-build', function() {
+gulp.task('compile-build', function(done) {
   gulp.src('./lcars/stylus/lcars.styl')
     .pipe(
       stylus({
@@ -58,10 +60,11 @@ gulp.task('compile-build', function() {
     .pipe( minify() )
     .pipe( rename('lcars.min.css') )
     .pipe( gulp.dest('./lcars/css') );
+  done();
 });
 
 gulp.task('watch', function() {
-  gulp.watch(paths.coreFiles, ['compile-dev']);
+  gulp.watch(paths.coreFiles, gulp.parallel(['compile-dev']));
 });
 
-gulp.task('default', ['compile-dev', 'compile','compile-build']);
+gulp.task('default', gulp.parallel(['compile-dev', 'compile','compile-build']));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/Garrett-/lcars",
   "devDependencies": {
     "rupture": "^0.1.0",
-    "gulp": "^3.6.2",
+    "gulp": "^4.0.2",
     "stylus": "^0.44.0",
     "nib": "^1.0.2",
     "gulp-stylus": "^1.0.0",


### PR DESCRIPTION
In reference to issue #43, this branch would update the gulpfile.js with the `parallel` function and `done` callbacks to allow migration to Gulp 4.

The change to package.json updates the version referenced in the package to 4.0.2

I'm new to package managers, but if I understand it right, developers/contributors may need to run 
`npm update gulp@latest` 
or
`yarn upgrade gulp@latest`
to get their environments on the new version of Gulp.